### PR TITLE
[clickhouse-backup]Set read_timeout in the connect string

### DIFF
--- a/pkg/clickhouse/clickhouse.go
+++ b/pkg/clickhouse/clickhouse.go
@@ -42,6 +42,7 @@ func (ch *ClickHouse) Connect() error {
 	params.Add("password", ch.Config.Password)
 	params.Add("database", "system")
 	params.Add("receive_timeout", timeoutSeconds)
+	params.Add("read_timeout", timeoutSeconds)
 	params.Add("send_timeout", timeoutSeconds)
 	if ch.Config.Secure {
 		params.Add("secure", "true")
@@ -51,6 +52,7 @@ func (ch *ClickHouse) Connect() error {
 		params.Add("log_queries", "0")
 	}
 	connectionString := fmt.Sprintf("tcp://%v:%v?%s", ch.Config.Host, ch.Config.Port, params.Encode())
+	log.Debug(connectionString)
 	if ch.conn, err = sqlx.Open("clickhouse", connectionString); err != nil {
 		return err
 	}


### PR DESCRIPTION
## summary

For large datasets like ch-cdnvideolog a `read_timeout` needs to be set in the database connect string.  

## testing

```
create -t default.enriched_video_access_log_records FULL_ch-cdnvideolog-0-1_default.enriched_video_access_log_records_20210811_1648
2021/08/11 16:48:43 debug tcp://localhost:9000?database=system&log_queries=0&password=&read_timeout=300&receive_timeout=300&send_timeout=300&username=default
2021/08/11 16:48:43 debug SELECT name, engine FROM system.databases WHERE name != 'system'
2021/08/11 16:48:43 debug SHOW CREATE DATABASE `_temporary_and_external_tables`
2021/08/11 16:48:43 debug SHOW CREATE DATABASE `default`
2021/08/11 16:48:43 debug SELECT count() FROM system.settings WHERE name = 'show_table_uuid_in_table_create_query_if_not_nil'
2021/08/11 16:48:43 debug SELECT * FROM system.tables WHERE is_temporary = 0 SETTINGS show_table_uuid_in_table_create_query_if_not_nil=1
2021/08/11 16:48:43 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/08/11 16:48:43 debug SELECT * FROM system.disks;
2021/08/11 16:48:43 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/08/11 16:48:43 debug SELECT * FROM system.disks;
2021/08/11 16:48:43 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/08/11 16:48:43 debug SELECT * FROM system.disks;
2021/08/11 16:48:43 debug create data               backup=FULL_ch-cdnvideolog-0-1_default.enriched_video_access_log_records_20210811_1648 operation=create table=default.enriched_video_access_log_records
2021/08/11 16:48:43 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/08/11 16:48:43 debug SELECT * FROM system.disks;
2021/08/11 16:48:43 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/08/11 16:48:43 debug SYSTEM SYNC REPLICA `default`.`enriched_video_access_log_records`;
2021/08/11 16:48:43 debug replica synced            table=default.enriched_video_access_log_records
2021/08/11 16:48:43 debug ALTER TABLE `default`.`enriched_video_access_log_records` FREEZE WITH NAME 'fa484d669e6e40efa3f954c9e71da51f';
2021/08/11 16:50:22 debug freezed                   backup=FULL_ch-cdnvideolog-0-1_default.enriched_video_access_log_records_20210811_1648 operation=create table=default.enriched_video_access_log_records
2021/08/11 16:52:16 debug shadow moved              backup=FULL_ch-cdnvideolog-0-1_default.enriched_video_access_log_records_20210811_1648 disk=default operation=create table=default.enriched_video_access_log_records
2021/08/11 16:52:17 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/08/11 16:52:17 debug SELECT * FROM system.disks;
2021/08/11 16:52:17 debug done                      backup=FULL_ch-cdnvideolog-0-1_default.enriched_video_access_log_records_20210811_1648 operation=create table=default.enriched_video_access_log_records
2021/08/11 16:52:17 debug create metadata           backup=FULL_ch-cdnvideolog-0-1_default.enriched_video_access_log_records_20210811_1648 operation=create table=default.enriched_video_access_log_records
2021/08/11 16:52:17  info done                      backup=FULL_ch-cdnvideolog-0-1_default.enriched_video_access_log_records_20210811_1648 operation=create table=default.enriched_video_access_log_records
2021/08/11 16:52:17 debug SELECT value FROM `system`.`build_options` where name='VERSION_DESCRIBE'
2021/08/11 16:52:17  info done                      backup=FULL_ch-cdnvideolog-0-1_default.enriched_video_access_log_records_20210811_1648 operation=create
```